### PR TITLE
Trucker is now initialized immediately, regardless of routing

### DIFF
--- a/src/Trucker/TruckerServiceProvider.php
+++ b/src/Trucker/TruckerServiceProvider.php
@@ -31,7 +31,6 @@ class TruckerServiceProvider extends ServiceProvider
     public function boot()
     {
         // Register classes
-        $this->app = static::make($this->app);
     }
 
     /**
@@ -42,6 +41,7 @@ class TruckerServiceProvider extends ServiceProvider
     public function register()
     {
         // done with boot()
+        $this->app = static::make($this->app);
     }
 
     /**


### PR DESCRIPTION
I'm running into issues where Trucker services are not loaded when I need them to be.  Migrating the initialization to `register()` resolves the issue.

From Laravel docs:

> The `register` method is called immediately when the service provider is registered, while the `boot` command is only called right before a request is routed.
