### PR TITLE
URI path_prefix added 

### DIFF
--- a/src/Trucker/Finders/CollectionFinder.php
+++ b/src/Trucker/Finders/CollectionFinder.php
@@ -104,6 +104,11 @@ class CollectionFinder
         //figure out wether a collection key is used
         $collection_key = Config::get('resource.collection_key');
 
+        //if collection key is a CLosure, call the closure
+        if ($collection_key instanceof \Closure) {
+            $collection_key = $collection_key($model);
+        }
+
         //set records array appropriatley
         if (isset($collection_key)) {
             $recordCollection = $data[$collection_key];

--- a/src/Trucker/Resource/Model.php
+++ b/src/Trucker/Resource/Model.php
@@ -21,6 +21,7 @@ use Trucker\Facades\ErrorHandlerFactory;
 use Trucker\Facades\AuthFactory;
 use Trucker\Finders\Conditions\QueryConditionInterface;
 use Trucker\Finders\Conditions\QueryResultOrderInterface;
+use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Base class for interacting with a remote API.
@@ -53,6 +54,13 @@ class Model
      * @var string
      */
     protected $uri;
+
+    /**
+     * The pluralized version of the resource name, ie a Page Model would become 'pages'
+     * 
+     * @var string
+     */
+    protected $pluralized;
 
     /**
      * Property to hold the data about entities for which this
@@ -491,6 +499,17 @@ class Model
     public function getURI()
     {
         return $this->uri ?: null;
+    }
+
+    public function pluralize() {
+        if (!isset($this->pluralized)) {
+            $this->pluralized = Inflector::pluralize(
+                Inflector::tableize(
+                    $this->getResourceName()
+                )
+            );
+        }
+        return $this->pluralized;
     }
 
 

--- a/src/Trucker/Support/ConfigManager.php
+++ b/src/Trucker/Support/ConfigManager.php
@@ -63,9 +63,9 @@ class ConfigManager
      *
      * @return mixed
      */
-    public function get($option)
+    public function get($option, $default = null)
     {
-        return $this->app['config']->get('trucker::'.$option);
+        return $this->app['config']->get('trucker::'.$option, $default);
     }
 
 

--- a/src/Trucker/Url/UrlGenerator.php
+++ b/src/Trucker/Url/UrlGenerator.php
@@ -12,6 +12,7 @@ namespace Trucker\Url;
 
 use Illuminate\Container\Container;
 use Doctrine\Common\Inflector\Inflector;
+use Trucker\Facades\Config;
 
 class UrlGenerator
 {
@@ -172,6 +173,7 @@ class UrlGenerator
             $uri = implode("/", $uriResult) . "/$uri";
         }
 
-        return "/$uri";
+        $prefix = Config::get('request.path_prefix','/');
+        return "{$prefix}{$uri}";
     }
 }

--- a/src/Trucker/Url/UrlGenerator.php
+++ b/src/Trucker/Url/UrlGenerator.php
@@ -146,11 +146,7 @@ class UrlGenerator
             return $uri;
         }
 
-        $uri = Inflector::pluralize(
-            Inflector::tableize(
-                $model->getResourceName()
-            )
-        );
+        $uri = $model->pluralize();
 
         $uriResult = [];
         if (!empty($model->nestedUnder)) {

--- a/src/config/request.php
+++ b/src/config/request.php
@@ -2,7 +2,7 @@
 
     /*
     |--------------------------------------------------------------------------
-    | API endpoint URI
+    | API endpoint base URI
     |--------------------------------------------------------------------------
     |
     | This is the base URI that your API requests will be made to.
@@ -11,6 +11,18 @@
     */
 
     'base_uri' => 'http://example.com',
+    
+    /*
+    |--------------------------------------------------------------------------
+    | API endpoint path
+    |--------------------------------------------------------------------------
+    |
+    | This is the optional path where the API endpoint is located under, 
+    | for instance /admin/ would result in http://example.com/admin/
+    |
+    |
+    */
+    'path_prefix' => '/',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/resource.php
+++ b/src/config/resource.php
@@ -19,7 +19,10 @@
     |
     | When returning a collection of items ( /products for example ) if your API
     | provides the collection within a sub element of the response it can be defined
-    | here.
+    | here. It can be a simple string, or a Closure to determine the key. For example
+    | function(Trucker\Resource\Model $model) {
+    |     return $model->pluralize();
+    | }
     |
     */
 


### PR DESCRIPTION
I had trouble using the shopify API with Trucker because their API resides under a subdirectory, 
eg https://example.myshopify.com/admin/
I found the nestedUnder function for models, but this is not working properly, ie for the ::all method
Maybe I missed something, but I think this proposed mod is the only way to solve this.