### PR TITLE
1.0 - Fix for using non-default identity property

### DIFF
--- a/src/Trucker/Finders/InstanceFinder.php
+++ b/src/Trucker/Finders/InstanceFinder.php
@@ -63,7 +63,7 @@ class InstanceFinder
         //init the request
         $request->createRequest(
             Config::get('request.base_uri'),
-            UrlGenerator::getInstanceUri($model, [':id' => $id]),
+            UrlGenerator::getInstanceUri($model, [':'.$model->getIdentityProperty() => $id]),
             'GET'
         );
 

--- a/src/Trucker/Url/UrlGenerator.php
+++ b/src/Trucker/Url/UrlGenerator.php
@@ -122,7 +122,7 @@ class UrlGenerator
      */
     public function getInstanceUri($model, $options = array())
     {
-        $uri = implode("/", array($this->getURI($model), ':id'));
+        $uri = implode("/", array($this->getURI($model), ':'.$model->getIdentityProperty()));
         foreach ($options as $key => $value) {
             $uri = str_replace($key, $value, $uri);
         }


### PR DESCRIPTION
BUG - Previously when using non-standard identity properties, the URL generated when POSTing saved changes included the static text ':id' when the ID field was set to something else - eg. :entry_id.